### PR TITLE
Fix grafana_data is not saved due to unmapped volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     volumes:
       - ./grafana/dashboards:/var/lib/grafana/dashboards
       - ./grafana/provisioning:/etc/grafana/provisioning
+      - grafana_data:/var/lib/grafana
     ports:
       - 9999:3000
     networks:


### PR DESCRIPTION
Currently, when we `docker compose down`. Grafana data is removed because grafana_data volume is not mapped.