### PR TITLE
Fix alert NoReceiverMetricPoints 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     volumes:
       - ./grafana/dashboards:/var/lib/grafana/dashboards
       - ./grafana/provisioning:/etc/grafana/provisioning
+      - grafana_data:/var/lib/grafana
     ports:
       - 9999:3000
     networks:

--- a/prometheus/alerts/alert.rules
+++ b/prometheus/alerts/alert.rules
@@ -26,7 +26,7 @@ groups:
         description: 'Block production stalled. The node has not produced any blocks in the last 5 minutes.'
 
     - alert: NoReceiverMetricPoints
-      expr: increase(otelcol_receiver_accepted_metric_points[1m]) == 0
+      expr: increase(otelcol_receiver_accepted_metric_points_total[1m]) == 0
       for: 3m
       labels:
         severity: critical


### PR DESCRIPTION
We don't receive any alert when our bridge node is down. So, we went to check why NoReceiverMetricPoints doesn't emit and found out that we need to use `otelcol_receiver_accepted_metric_points_total` instead of `otelcol_receiver_accepted_metric_points`